### PR TITLE
Fix Boolean schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+#### v3.0.0
+
+- Fixed a bug where the boolean `false` schema accepted was treated as `true` (i.e. `validate(false)` will now always fail instead of always succeeding.)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Here is a list of possible `message` values for errors:
 * `has less length than allowed`
 * `is less than minimum`
 * `is more than maximum`
+* `never matches`
 
 ## Performance
 

--- a/index.js
+++ b/index.js
@@ -171,6 +171,10 @@ var compile = function(schema, cache, root, reporter, opts) {
       }
     }
 
+    if (node === false) {
+      error('never matches')
+    }
+
     if (node.required === true) {
       indent++
       validate('if (%s === undefined) {', name)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "is-my-json-valid",
-  "version": "2.17.1",
+  "version": "3.0.0",
   "description": "A JSONSchema validator that uses code generation to be extremely fast",
   "main": "index.js",
   "dependencies": {

--- a/test/extra/boolean.json
+++ b/test/extra/boolean.json
@@ -1,0 +1,94 @@
+[
+    {
+        "description": "boolean true matches anything",
+        "schema": true,
+        "tests": [
+            {
+                "description": "boolean true matches true",
+                "data": true,
+                "valid": true
+            },
+            {
+                "description": "boolean true matches false",
+                "data": false,
+                "valid": true
+            },
+            {
+                "description": "boolean true matches an integer",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "boolean true matches a float",
+                "data": 1.1,
+                "valid": true
+            },
+            {
+                "description": "boolean true matches a string",
+                "data": "foo",
+                "valid": true
+            },
+            {
+                "description": "boolean true matches an object",
+                "data": {},
+                "valid": true
+            },
+            {
+                "description": "boolean true matches an array",
+                "data": [],
+                "valid": true
+            },
+            {
+                "description": "boolean true matches null",
+                "data": null,
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "boolean false matches nothing",
+        "schema": false,
+        "tests": [
+            {
+                "description": "boolean false does not match true",
+                "data": true,
+                "valid": false
+            },
+            {
+                "description": "boolean false does not match false",
+                "data": false,
+                "valid": false
+            },
+            {
+                "description": "boolean false does not match an integer",
+                "data": 1,
+                "valid": false
+            },
+            {
+                "description": "boolean false does not match a float",
+                "data": 1.1,
+                "valid": false
+            },
+            {
+                "description": "boolean false does not match a string",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "boolean false does not match an object",
+                "data": {},
+                "valid": false
+            },
+            {
+                "description": "boolean false does not match an array",
+                "data": [],
+                "valid": false
+            },
+            {
+                "description": "boolean false does not match null",
+                "data": null,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -22,3 +22,6 @@ var loadAndRunTests = suiteName =>
 
 readDir('json-schema-draft4', {excluding: ['definitions.json', 'refRemote.json']})
   .forEach(loadAndRunTests('json-schema-test-suite'))
+
+readDir('extra')
+  .forEach(loadAndRunTests('extra-test-suite'))

--- a/test/json-schema.js
+++ b/test/json-schema.js
@@ -2,22 +2,23 @@ var tape = require('tape')
 var fs = require('fs')
 var validator = require('../')
 
-var files = fs.readdirSync(__dirname+'/json-schema-draft4')
-  .map(function(file) {
-    if (file === 'definitions.json') return null
-    if (file === 'refRemote.json') return null
-    return require('./json-schema-draft4/'+file)
-  })
-  .filter(Boolean)
+var readDir = function(dir, {excluding} = {excluding: []}) {
+  return fs.readdirSync(__dirname+'/'+dir)
+    .filter(file => ! (Array.isArray(excluding) && excluding.includes(file)))
+    .map(file => './'+dir+'/'+file)
+}
 
-files.forEach(function(file) {
-  file.forEach(function(f) {
-    tape('json-schema-test-suite '+f.description, function(t) {
-      var validate = validator(f.schema)
-      f.tests.forEach(function(test) {
-        t.same(validate(test.data), test.valid, test.description)
+var loadAndRunTests = suiteName =>
+  fileName => require(fileName)
+    .forEach(f =>
+      tape(suiteName+' '+f.description, t => {
+        var validate = validator(f.schema)
+        f.tests.forEach(function(test) {
+          t.same(validate(test.data), test.valid, test.description)
+        })
+        t.end()
       })
-      t.end()
-    })
-  })
-})
+    )
+
+readDir('json-schema-draft4', {excluding: ['definitions.json', 'refRemote.json']})
+  .forEach(loadAndRunTests('json-schema-test-suite'))


### PR DESCRIPTION
This PR fixes a bug in `is-my-json-valid` where the boolean schema `false` is incorrectly treated as `true`.

According to the the [spec](http://json-schema.org/latest/json-schema-core.html#rfc.section.4.3.1), `false` is a valid schema that will not match any data, but `is-my-json-valid` incorrectly treats it as an empty schema, meaning it accepts anything instead:

```js
var validate = require('is-my-json-valid')(false);
[null, 12, "a string", {foo: "bar"}].map(validate);
// => [ true, true, true, true ]
```

With no explicit handling for boolean schemas, and 
Since true and false are objects in javascript, having no explicit handling means they're both treated like `{}`, which is a happy coincidence for `true`, and a less fortunate one for `false` :)
