### PR TITLE
Add check for boolean true schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,6 +171,10 @@ var compile = function(schema, cache, root, reporter, opts) {
       }
     }
 
+    if (node === true) {
+      return
+    }
+
     if (node.required === true) {
       indent++
       validate('if (%s === undefined) {', name)


### PR DESCRIPTION
When evaluating the `true` schema, the resulting validator has an empty (and somewhat suspicious) check for definedness:
```
 $ node -e 'console.log((require("./index.js")({allOf:[true,true,true]})).toString())'
function validate(data) {
  if (data === undefined) data = null
  validate.errors = null
  var errors = 0
  if (data !== undefined) {
    if (data !== undefined) {
    }
    if (data !== undefined) {
    }
    if (data !== undefined) {
    }
  }
  return errors === 0
}
```

This PR adds a check for this case, removing this check.

```
$ node -e 'console.log((require("./index.js")({allOf:[true,true,true]})).toString())'
function validate(data) {
  if (data === undefined) data = null
  validate.errors = null
  var errors = 0
  if (data !== undefined) {
  }
  return errors === 0
}
```

This looks like it would should result in a small performance boost for any validator that includes `true` as a schema. V8 does some very fancy optimizations, so caveats, but it looks like a straightforward "better" to me.

The early return will also short-circuit the compilation process, which is a bit more complicated.

The short circuit will make compiling the `true` subschema significantly faster; Currently, it's treated as an object, and the current implementation checks for every possible keyword.

However, it will also add that check to every other sub-schema. It's a cheap check, but it does mean that compilation of schemas that don't include `true` as a achema will be slower.

I'm not sure how to value compilation time either. Shorter is obviously better, but if we're talking about tradeoffs we really need some relevant benchmarks to do anything useful.

There are JSON Schema benchmarks (https://github.com/ebdrup/json-schema-benchmark is the most up-to-date I can find), so we should run at least that and get a positive result before we open an upstream PR.

Also, if compilation time is an issue we may get better results by pre-compiling schemas. The compiled schemas tend to be a lot more verbose than the JSON that generated them though, so we'd probably be trading load-time for run time which might make sense, but again, benchmarks.

How many times do we use `true` as schemas in calypso? How important is compilation time to us? It might  make more sense for us to make a like this under an `Automattic` fork - it would be far easier to show that a change like this is good for us than good for everybody.